### PR TITLE
Optimize navigation animation

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,42 +1,15 @@
 import React from 'react';
 import './App.less';
 import MainContent from './MainContent/MainContent.jsx';
+import MenuOpenStateHandler from './MenuOpenStateHandler/MenuOpenStateHandler.jsx';
+import MenuFullStateHandler from './MenuFullStateHandler/MenuFullStateHandler.jsx';
 import NavMenu from './NavMenu/NavMenu.jsx';
 import action, { ACTIONS } from '../action/action.js';
 import { matchParams } from '../utils/routes.js';
-import classNames from 'classnames';
 
 class App extends React.Component {
 
-  constructor() {
-    super();
-    this.state = {
-      open: false,
-      full: false,
-    };
-  }
-
   componentDidMount() {
-    this.obsToggleNavMenu = action
-    .filter(a => a.name === ACTIONS.TOGGLE_NAV_MENU)
-    .subscribe(() => {
-      this.setState({ open: !this.state.open, full: false });
-    });
-    this.obsOpenNavMenu = action
-    .filter(a => a.name === ACTIONS.OPEN_NAV_MENU)
-    .subscribe(() => {
-      this.setState({ open: true, full: false });
-    });
-    this.obsFullNavMenu = action
-    .filter(a => a.name === ACTIONS.FULL_NAV_MENU)
-    .subscribe(() => {
-      this.setState({ open: true, full: true });
-    });
-    this.obsCloseNavMenu = action
-    .filter(a => a.name === ACTIONS.CLOSE_NAV_MENU)
-    .subscribe(() => {
-      this.setState({ open: false, full: false });
-    });
     this.obsBackButton = action
     .filter(a => a.name === ACTIONS.BACK_BUTTON)
     .subscribe(a => {
@@ -46,30 +19,22 @@ class App extends React.Component {
   }
 
   componentWillUnmount() {
-    this.obsOpenNavMenu.dispose();
-    this.obsFullNavMenu.dispose();
-    this.obsCloseNavMenu.dispose();
-    this.obsToggleNavMenu.dispose();
     this.obsBackButton.dispose();
   }
 
   render() {
     return (
       <div>
+        <MenuOpenStateHandler />
+        <MenuFullStateHandler />
         <div
           id="menu-overlay"
-          className={classNames({ show: this.state.open && !this.state.full })}
           onClick={() => action.onNext({ name: ACTIONS.CLOSE_NAV_MENU })}
         ></div>
-        <NavMenu
-          open={this.state.open}
-          full={this.state.full}
-        />
+        <NavMenu />
         <MainContent
           route={this.props.routes[this.props.routes.length - 1].path}
           location={this.props.location}
-          open={this.state.open}
-          full={this.state.full}
         >
           {this.props.children}
         </MainContent>

--- a/src/components/App.less
+++ b/src/components/App.less
@@ -55,9 +55,6 @@ a {
   bottom: 0;
   z-index: 3;
   transform: translate3d(-1000px, 0, 0);
-  &.show {
-    transform: translate3d(0, 0, 0);
-  }
 }
 
 .list-appear, .list-enter {

--- a/src/components/MainContent/style.less
+++ b/src/components/MainContent/style.less
@@ -9,14 +9,6 @@
   width: 100%;
   background-color: rgba(15, 32, 53, 1);
 
-  &.open {
-    transform: translate3d(84%, 0, 0);
-    &.full {
-      transform: translate3d(100%, 0, 0);
-      box-shadow: none;
-    }
-  }
-
   #scroll-section {
     position: absolute;
     overflow-y: scroll; /* has to be scroll, not auto */

--- a/src/components/MenuFullStateHandler/MenuFullStateHandler.jsx
+++ b/src/components/MenuFullStateHandler/MenuFullStateHandler.jsx
@@ -7,39 +7,26 @@ export default class MenuFullStateHandler extends React.Component {
   constructor() {
     super();
     this.state = {
-      open: false,
       full: false,
     };
   }
 
   componentDidMount() {
-    this.obsToggleNavMenu = action
-    .filter(a => a.name === ACTIONS.TOGGLE_NAV_MENU)
-    .subscribe(() => {
-      this.setState({ open: !this.state.open, full: false });
-    });
-    this.obsOpenNavMenu = action
-    .filter(a => a.name === ACTIONS.OPEN_NAV_MENU)
-    .subscribe(() => {
-      this.setState({ open: true, full: false });
-    });
     this.obsFullNavMenu = action
     .filter(a => a.name === ACTIONS.FULL_NAV_MENU)
     .subscribe(() => {
-      this.setState({ open: true, full: true });
+      this.setState({ full: true });
     });
     this.obsCloseNavMenu = action
-    .filter(a => a.name === ACTIONS.CLOSE_NAV_MENU)
+    .filter(a => a.name === ACTIONS.CLOSE_NAV_MENU || a.name === ACTIONS.OPEN_NAV_MENU)
     .subscribe(() => {
-      this.setState({ open: false, full: false });
+      this.setState({ full: false });
     });
   }
 
   componentWillUnmount() {
-    this.obsOpenNavMenu.dispose();
     this.obsFullNavMenu.dispose();
     this.obsCloseNavMenu.dispose();
-    this.obsToggleNavMenu.dispose();
   }
 
   render() {

--- a/src/components/MenuFullStateHandler/MenuFullStateHandler.jsx
+++ b/src/components/MenuFullStateHandler/MenuFullStateHandler.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import action, { ACTIONS } from '../../action/action.js';
+import './style.less';
+
+export default class MenuFullStateHandler extends React.Component {
+
+  constructor() {
+    super();
+    this.state = {
+      open: false,
+      full: false,
+    };
+  }
+
+  componentDidMount() {
+    this.obsToggleNavMenu = action
+    .filter(a => a.name === ACTIONS.TOGGLE_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: !this.state.open, full: false });
+    });
+    this.obsOpenNavMenu = action
+    .filter(a => a.name === ACTIONS.OPEN_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: true, full: false });
+    });
+    this.obsFullNavMenu = action
+    .filter(a => a.name === ACTIONS.FULL_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: true, full: true });
+    });
+    this.obsCloseNavMenu = action
+    .filter(a => a.name === ACTIONS.CLOSE_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: false, full: false });
+    });
+  }
+
+  componentWillUnmount() {
+    this.obsOpenNavMenu.dispose();
+    this.obsFullNavMenu.dispose();
+    this.obsCloseNavMenu.dispose();
+    this.obsToggleNavMenu.dispose();
+  }
+
+  render() {
+    return (
+      <input type="checkbox" id="nav-menu-full-checkbox" checked={this.state.full} />
+    );
+  }
+
+}

--- a/src/components/MenuFullStateHandler/style.less
+++ b/src/components/MenuFullStateHandler/style.less
@@ -1,0 +1,16 @@
+input#nav-menu-full-checkbox {
+  display: none;
+}
+
+input#nav-menu-full-checkbox:checked ~ #menu-overlay {
+  transform: translate3d(-1000px, 0, 0);
+}
+
+input#nav-menu-full-checkbox:checked ~ #main-content {
+  transform: translate3d(100%, 0, 0);
+  box-shadow: none;
+}
+
+input#nav-menu-full-checkbox:checked ~ #nav-menu #cancel-button {
+  opacity: 0.5;
+}

--- a/src/components/MenuOpenStateHandler/MenuOpenStateHandler.jsx
+++ b/src/components/MenuOpenStateHandler/MenuOpenStateHandler.jsx
@@ -8,7 +8,6 @@ export default class MenuOpenStateHandler extends React.Component {
     super();
     this.state = {
       open: false,
-      full: false,
     };
   }
 
@@ -16,28 +15,22 @@ export default class MenuOpenStateHandler extends React.Component {
     this.obsToggleNavMenu = action
     .filter(a => a.name === ACTIONS.TOGGLE_NAV_MENU)
     .subscribe(() => {
-      this.setState({ open: !this.state.open, full: false });
+      this.setState({ open: !this.state.open });
     });
     this.obsOpenNavMenu = action
     .filter(a => a.name === ACTIONS.OPEN_NAV_MENU)
     .subscribe(() => {
-      this.setState({ open: true, full: false });
-    });
-    this.obsFullNavMenu = action
-    .filter(a => a.name === ACTIONS.FULL_NAV_MENU)
-    .subscribe(() => {
-      this.setState({ open: true, full: true });
+      this.setState({ open: true });
     });
     this.obsCloseNavMenu = action
     .filter(a => a.name === ACTIONS.CLOSE_NAV_MENU)
     .subscribe(() => {
-      this.setState({ open: false, full: false });
+      this.setState({ open: false });
     });
   }
 
   componentWillUnmount() {
     this.obsOpenNavMenu.dispose();
-    this.obsFullNavMenu.dispose();
     this.obsCloseNavMenu.dispose();
     this.obsToggleNavMenu.dispose();
   }

--- a/src/components/MenuOpenStateHandler/MenuOpenStateHandler.jsx
+++ b/src/components/MenuOpenStateHandler/MenuOpenStateHandler.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import action, { ACTIONS } from '../../action/action.js';
+import './style.less';
+
+export default class MenuOpenStateHandler extends React.Component {
+
+  constructor() {
+    super();
+    this.state = {
+      open: false,
+      full: false,
+    };
+  }
+
+  componentDidMount() {
+    this.obsToggleNavMenu = action
+    .filter(a => a.name === ACTIONS.TOGGLE_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: !this.state.open, full: false });
+    });
+    this.obsOpenNavMenu = action
+    .filter(a => a.name === ACTIONS.OPEN_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: true, full: false });
+    });
+    this.obsFullNavMenu = action
+    .filter(a => a.name === ACTIONS.FULL_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: true, full: true });
+    });
+    this.obsCloseNavMenu = action
+    .filter(a => a.name === ACTIONS.CLOSE_NAV_MENU)
+    .subscribe(() => {
+      this.setState({ open: false, full: false });
+    });
+  }
+
+  componentWillUnmount() {
+    this.obsOpenNavMenu.dispose();
+    this.obsFullNavMenu.dispose();
+    this.obsCloseNavMenu.dispose();
+    this.obsToggleNavMenu.dispose();
+  }
+
+  render() {
+    return (
+      <input type="checkbox" id="nav-menu-open-checkbox" checked={this.state.open} />
+    );
+  }
+
+}

--- a/src/components/MenuOpenStateHandler/style.less
+++ b/src/components/MenuOpenStateHandler/style.less
@@ -1,0 +1,17 @@
+input#nav-menu-open-checkbox {
+  display: none;
+}
+
+input#nav-menu-open-checkbox:checked ~ #menu-overlay {
+  transform: translate3d(0, 0, 0);
+}
+
+input#nav-menu-open-checkbox:checked ~ #main-content {
+  transform: translate3d(84%, 0, 0);
+}
+
+input#nav-menu-open-checkbox:checked ~ #nav-menu {
+  opacity: 0.99;
+  transform: translate3d(0, 0, 0);
+}
+

--- a/src/components/NavMenu/style.less
+++ b/src/components/NavMenu/style.less
@@ -8,11 +8,6 @@
   transition: transform 0.3s cubic-bezier(0.7, 0, 0.25, 1),
               opacity 0.4s;
 
-  &.open {
-    opacity: 0.99;
-    transform: translate3d(0, 0, 0);
-  }
-
   #search-bar {
     position: relative;
     padding: 15px;
@@ -40,10 +35,6 @@
       opacity: 0;
       transition: opacity 0.3s 0.2s;
       font-size: 14px;
-
-      &.show {
-        opacity: 0.5;
-      }
     }
   }
 


### PR DESCRIPTION
Problem:
====

Currently, the state of navigation menu is managed in the `App` component. This is very bad since `App` is the root component of the application, and we don't want to re-render the whole application just to open and close the navigation menu.

Take a look and `App` component's `render` method:

```js
  render() {
    return (
      <div>
        <div
          id="menu-overlay"
          className={classNames({ show: this.state.open && !this.state.full })}
          onClick={() => action.onNext({ name: ACTIONS.CLOSE_NAV_MENU })}
        ></div>
        <NavMenu
          open={this.state.open}
          full={this.state.full}
        />
        <MainContent
          route={this.props.routes[this.props.routes.length - 1].path}
          location={this.props.location}
          open={this.state.open}
          full={this.state.full}
        >
          {this.props.children}
        </MainContent>
      </div>
    );
  }
```

There you see the `this.state.open` and `this.state.full` is too states that handle the position of the navigation menu, and these states are **passed down to children elements** to tell them render differently when each state change, which require React to execute `render` on all those children component for reconciliation and running diff algorithm. See the timeline record for a simple "open menu" action:

![before](https://cloud.githubusercontent.com/assets/4214509/16980021/5f7f7e7e-4e8e-11e6-94d3-4deca155f492.png)

(I recorded this on my 5-year-old **Samsung Galaxy S3 Mini**, running Android 4.1.2, in Debug mode for DevTools, so please don't be surprise that it took 2500ms to execute that amount of JavaScript)

Solution
===
Inspired from this awesome idea: [You-Dont-Need-Javascript](https://github.com/NamPNQ/You-Dont-Need-Javascript), I think that it could be nice to get those navigation menu states out of the App component, then we don't have to render the App component again every time user open/close the menu.

Ok, so this is how I do that:
- Moves the state to a new component, called `MenuOpenStateHandler` and `MenuFullStateHandler`.
- Use checkboxes and CSS selectors to handle open/close state of the menu.

If you read the link above, you'll know that we could completely handle the navigation state **without JavaScript** at all (by using checkbox state and label). But if we do that, it would be a hard time for us to manage the state in our application because we **still want to manage the open/close state** so we can do things like close menu when click to a user item without using too much CSS hacks.

The App component's `render` method is now look like this:

```js
  render() {
    return (
      <div>
        <MenuOpenStateHandler />
        <MenuFullStateHandler />
        <div
          id="menu-overlay"
          onClick={() => action.onNext({ name: ACTIONS.CLOSE_NAV_MENU })}
        ></div>
        <NavMenu />
        <MainContent
          route={this.props.routes[this.props.routes.length - 1].path}
          location={this.props.location}
        >
          {this.props.children}
        </MainContent>
      </div>
    );
  }
```

The states are completely moved to the `MenuOpenStateHandler` and `MenuFullStateHandler` so now the `App` component will not get re-render every time those states change.

See timeline record for the open menu action (still on that same phone):

![after](https://cloud.githubusercontent.com/assets/4214509/16979991/3a139350-4e8e-11e6-92f7-faed7a427997.png)

See detail changes in the PR.

**Performance win!**
