### PR TITLE
Add instructions to install bower components

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ This project is bootstraped from [plain-react](https://github.com/trungdq88/plai
 Make sure you have NodeJS v6 or above. 
 
 ```bash  
-npm install 
+npm install
+bower install
 npm start 
 ``` 
 


### PR DESCRIPTION
Running `npm install` and then `npm start` as the `README` suggests fails as bower components aren't installed.